### PR TITLE
Add OS X-flavored config directory, correct error-message typo

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ func (c *Config) Parse(data []byte) error {
 		return errors.New("not following anyone!")
 	}
 	if c.Nick == "" || c.Twturl == "" {
-		return errors.New("both nick and twtwurl must be set!")
+		return errors.New("both nick and twturl must be set!")
 	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,9 @@ func (c *Config) Read() string {
 	if xdg := os.Getenv("XDG_BASE_DIR"); xdg != "" {
 		paths = append(paths, fmt.Sprintf("%s/config/twet", xdg))
 	}
+	
 	paths = append(paths, fmt.Sprintf("%s/config/twet", os.Getenv("HOME")))
+	paths = append(paths, fmt.Sprintf("%s/Library/Application Support/twet", os.Getenv("HOME")))
 	paths = append(paths, fmt.Sprintf("%s/.twet", os.Getenv("HOME")))
 
 	filename := "config.yaml"


### PR DESCRIPTION
I wanted to add an OS X-flavored directory for twet config and data, plus I saw a user-facing typo that'd direct the user to add a key in the config that twet doesn't check.
