### PR TITLE
added check for file:// when loading twtxt.txt files

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -79,7 +79,10 @@ func (cache Cache) FetchTweets(sources map[string]string) {
 
 		// anon func takes needed variables as arg, avoiding capture of iterator variables
 		go func(nick string, url string) {
-			defer wg.Done()
+			defer func() {
+				<-fetchers
+				wg.Done()
+			}()
 
 			if strings.HasPrefix(url, "file://") {
 				err := ReadLocalFile(url, nick, &tweetsch, &cache, &mu)
@@ -150,8 +153,6 @@ func (cache Cache) FetchTweets(sources map[string]string) {
 			tweetsch <- tweets
 
 		}(nick, url)
-
-		<-fetchers
 	}
 
 	// close tweets channel when all goroutines are done

--- a/cache.go
+++ b/cache.go
@@ -7,9 +7,11 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 )
 
@@ -78,6 +80,16 @@ func (cache Cache) FetchTweets(sources map[string]string) {
 		// anon func takes needed variables as arg, avoiding capture of iterator variables
 		go func(nick string, url string) {
 			defer wg.Done()
+
+			if strings.HasPrefix(url, "file://") {
+				err := ReadLocalFile(url, nick, &tweetsch, &cache, &mu)
+				if err != nil {
+					if debug {
+						log.Printf("%s: Failed to read and cache local file: %s", url, err)
+					}
+				}
+				return
+			}
 
 			req, err := http.NewRequest("GET", url, nil)
 			if err != nil {
@@ -166,6 +178,40 @@ func (cache Cache) FetchTweets(sources map[string]string) {
 	if debug {
 		log.Print("\n")
 	}
+}
+
+func ReadLocalFile(url string, nick string, tweetsch *chan Tweets, cache *Cache, mu *sync.RWMutex) error {
+	path := string(url[6:])
+	file, err := os.Stat(path)
+	if err != nil {
+		if debug {
+			log.Printf("%s: Can't stat local file: %s", path, err)
+		}
+		return err
+	}
+	if cached, ok := (*cache)[url]; ok {
+		if cached.Lastmodified == file.ModTime().String() {
+			tweets := (*cache)[url].Tweets
+			*tweetsch <- tweets
+			return nil
+		}
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		if debug {
+			log.Printf("%s: Can't read local file: %s", path, err)
+		}
+		*tweetsch <- nil
+		return err
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	tweets := ParseFile(scanner, Tweeter{Nick: nick, URL: url})
+	lastmodified := file.ModTime().String()
+	mu.Lock()
+	(*cache)[url] = Cached{Tweets: tweets, Lastmodified: lastmodified}
+	mu.Unlock()
+	*tweetsch <- tweets
+	return nil
 }
 
 func (cache Cache) GetAll() Tweets {


### PR DESCRIPTION
`L183:cache.go` now has the function `ReadLocalFile()`, which, after a check for the `file://` prefix in a URL, will read the raw bytes of the file and store it as if it were a remote twtxt file. The modtime of the file is stored as well, to prevent redundant caches of unmodified files.

eg, `file://home/blah/twtxt.txt`

This is in reference to [issue 2](https://github.com/quite/twet/issues/2)

I'm also including a bugfix for a deadlock I noticed in the `L67:cache.go:FetchTweets()` function. Here is my commit message explaining the change:

```
bugfix: deadlock in L67:cache.go:FetchTweets()

The parent goroutine adds an empty struct{} to the 'fetchers'
channel, which has a buffer size of maxfetchers. When the
fetchers channel is full, the parent goroutine will block
on send until the channel empties. However, as the fetchers
channel is read from in the same goroutine, rather than the
child goroutines, the same thread of execution is expected
to read from the channel as is blocking on send. This will
block until the program is killed. As maxfetchers is set
to a sufficiently high value, this will not manifest unless
one has many people to follow and, as a result, over 50
twtxt.txt files to fetch at once.

Moving the fetchers channel read for each loop iteration
to the child goroutine allows the channel to be read on
a separate thread of execution from the one blocking on
send, preventing this deadlock while achieving the desired
ratelimiting behavior.
```