### PR TITLE
Fix redirect bug where nick -> url can change from under us and lookups fail (missing key)

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -156,7 +156,18 @@ func (cache Cache) FetchTweets(sources map[string]string) {
 
 			actualurl := resp.Request.URL.String()
 			if actualurl != url {
+				if debug {
+					log.Printf("feed for %s changed from %s to %s", nick, url, actualurl)
+				}
 				url = actualurl
+				conf.Following[nick] = url
+				if err := conf.Write(); err != nil {
+					if debug {
+						log.Printf("%s: conf.Write fail: %s", url, err)
+					}
+					tweetsch <- nil
+					return
+				}
 			}
 
 			var tweets Tweets

--- a/commands.go
+++ b/commands.go
@@ -147,6 +147,8 @@ func TimelineCommand(args []string) error {
 		return fmt.Errorf("error calculating last modified cache time: %s", err)
 	}
 
+	var sourceURL string
+
 	if !*dryFlag {
 		var sources = conf.Following
 		if *sourceFlag != "" {
@@ -156,11 +158,17 @@ func TimelineCommand(args []string) error {
 			}
 			sources = make(map[string]string)
 			sources[*sourceFlag] = url
-			*sourceFlag = url
+			sourceURL = url
 		}
 
 		cache.FetchTweets(sources)
 		cache.Store(configpath)
+
+		// Did the url for *sourceFlag change?
+		if sources[*sourceFlag] != conf.Following[*sourceFlag] {
+			sources[*sourceFlag] = conf.Following[*sourceFlag]
+			sourceURL = conf.Following[*sourceFlag]
+		}
 	}
 
 	if debug && *dryFlag {
@@ -169,7 +177,7 @@ func TimelineCommand(args []string) error {
 
 	var tweets Tweets
 	if *sourceFlag != "" {
-		tweets = cache.GetByURL(*sourceFlag)
+		tweets = cache.GetByURL(sourceURL)
 	} else {
 		for _, url := range conf.Following {
 			tweets = append(tweets, cache.GetByURL(url)...)


### PR DESCRIPTION
Took me a while to figure out that in fact the client was in fact following
redirects correctly but since the URL had changed fromunder us we were
attempting to handle this in the Cache goroutine handling logic but failed
to update the `nick -> url` mapping of `sources` and the `*sourceFlag`.

This meant that if you had a feed that suddenly started telling you it's
location had changed, you would stop seeing updates for that feed.

In testing and debugging this I also found that with a fresh cache
`twet timeline -f -s slashdot` for example would just not output
anything at all for that feed with this bug.

Now this is fixed for both cases :)