### PR TITLE
README: fix "TODO" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ twet is a simple client in Go for
 [`twtxt`](https://github.com/buckket/twtxt) -- *the decentralised, minimalist
 microblogging service for hackers*.
 
-Please see the [TODO](TODO.md).
+Please see the [TODO](README.md#todo).
 
 ## Configuration
 


### PR DESCRIPTION
Now that the TODO is in the README file as a section, instead of being on its
own file, we need to update the link accordingly.